### PR TITLE
Fix backend module and update tests

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -18,14 +18,12 @@ import tiktoken  # Token-Zähler
 load_dotenv()                                     # .env einlesen
 
 OPENAI_KEY = os.getenv("OPENAI_API_KEY")
-MODEL_ID   = os.getenv("PW_MODEL")
+MODEL_ID   = os.getenv("PW_MODEL", "gpt-3.5-turbo")
 SYS_PROMPT = os.getenv(
     "SYSTEM_PROMPT",
     "Das scheint nicht zu funktionieren, bitte melde zurück, dass der Prompt nicht stimmt"
 )
 
-if not MODEL_ID:
-    raise EnvironmentError("PW_MODEL ist nicht gesetzt. Bitte .env prüfen.")
 
 client = OpenAI()                                # Key wird aus Umgebung gezogen
 ENC     = tiktoken.encoding_for_model(MODEL_ID)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,6 @@
 fastapi
 uvicorn[standard]
 openai
+httpx==0.27.0
 python-dotenv
 tiktoken

--- a/backend/tests/test_bewertung.py
+++ b/backend/tests/test_bewertung.py
@@ -1,4 +1,18 @@
 from unittest.mock import patch
+import os
+import sys
+import types
+
+dummy_tiktoken = types.SimpleNamespace(
+    encoding_for_model=lambda model: types.SimpleNamespace(encode=lambda s: [])
+)
+sys.modules.setdefault("tiktoken", dummy_tiktoken)
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+os.environ.setdefault("PW_MODEL", "gpt-3.5-turbo")
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
 from fastapi.testclient import TestClient
 from backend.main import app
 


### PR DESCRIPTION
## Summary
- mark `backend` as a package
- set default model ID to avoid failing when env var is missing
- pin `httpx` for Starlette compatibility
- adjust tests to run without network

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869793ca92c832c94d454998e1f9501